### PR TITLE
"Fixed" plugin, added permission support, added changing password support and deleting accounts support.

### DIFF
--- a/checkserver.php
+++ b/checkserver.php
@@ -1,0 +1,88 @@
+<?
+//Rerouting Auth script, PHP version
+//By Thulinma, Sep 1 2011
+//License: Do what you want with it, but give me credit for at least the concept.
+//
+//Description:
+//Changes the reply to the server from miencraft to always be "YES", allowing all users to login.
+//A plugin can then check the login status afterwards, giving access to the named account or not.
+//
+//Usage:
+//Put an entry in the hosts file on the (minecraft) server rerouting "www.minecraft.net" to the IP
+//of the (web / HTTP) server this script is installed on.
+//Make sure the folder this script is in is writeable to the webserver, or at least make a file
+//called "logins.json" that is writeable to the webserver.
+//Configure the webserver to serve this file when http://www.minecraft.net/game/checkserver.jsp is
+//called. An example config excerpt for lighttpd:
+/*
+$HTTP["host"] =~ "(^|\.)minecraft.net$" {
+  server.document-root = "/home/thulinma/minecraft/fakeserver"
+  url.rewrite = ("^/game/checkserver.jsp(.*)$" => "/checkserver.php$1")
+}
+*/
+//Instead of /home/thulinma/minecraft/fakeserver you would of course put the path where you saved
+//this script yourself! The url rewrite will turn the jsp requests into PHP requests to this script.
+//
+//Server plugins can then call http://www.minecraft.net/game/checkserver.jsp?premium=[USERNAME HERE]
+//and will get a single word as response to indicate if the user is premium or not.
+//Responses: PREMIUM or NOTPREMIUM
+//This check will work only once per login, so new users signing in with the same name afterwards are
+//not seen as the same person unless they actually are the same person.
+//
+//Finally, this script has only one setting, it controls what login servers are accepted.
+//My default accepts both the official minecraft server as well as the mineshafter server.
+//You can add your own login server here or some other - I don't know how many exist.
+//If you do not want to accept mineshafter logins, simply remove it here from the array.
+//These servers will be checked in the order you put them in.
+$servers = Array("http://minecraft.net/game/checkserver.jsp", "http://mineshafter.appspot.com/game/checkserver.jsp");
+
+
+
+//Script starts here, you probably don't want to modify anything below here.
+
+
+//Load the current waitinglist.
+$log = json_decode(file_get_contents("logins.json"));
+
+//Check a user in the waitinglist
+if ($_REQUEST['premium']){
+  foreach ($log AS $num => $entry){
+    if ($entry->user == $_REQUEST['premium']){
+      if ($entry->authed == "YES"){echo "PREMIUM";}else{echo "NOTPREMIUM";}
+      unset($log[$num]);//remove the user from the waitinglist
+      file_put_contents("logins.json", json_encode($log));
+      die();
+    }
+  }
+  //not found? return the save answer (not premium) by default
+  die("NOTPREMIUM");
+}
+
+//check for proper config, if called without variables.
+if (!$_REQUEST['user'] && !$_REQUEST['serverId']){
+  if ($_SERVER["HTTP_HOST"] == "www.minecraft.net"){
+    die("The script is installed properly! Yay!");
+  }else{
+    die("Please add a line to your hosts file to reroute www.minecraft.net to the address of this server (localhost?)!");
+  }
+}
+
+$newvalue = Array("user" => $_REQUEST['user'], "authed" => "NO");
+
+//check all servers
+foreach ($servers AS $currserv){
+  $response = file_get_contents($currserv."?user=".$_REQUEST['user']."&serverId=".$_REQUEST['serverId']);
+  if ($response == "YES"){
+    $newvalue->authed = "YES";
+    $log[] = $newvalue;
+    file_put_contents("logins.json", json_encode($log));
+    //Return yes after a correct login is found.
+    die("YES");
+  }
+}
+
+//Store the failed auth.
+$log[] = $newvalue;
+file_put_contents("logins.json", json_encode($log));
+//Always return yes to the server - a plugin will further check it.
+die("YES");

--- a/src/archangel/authplayer/AuthDatabase.java
+++ b/src/archangel/authplayer/AuthDatabase.java
@@ -89,7 +89,31 @@ public class AuthDatabase {
 			}
 		}
 	}
-	
+
+	 public void delete(String user) {
+	    authMap.remove(user.toLowerCase());
+	    FileOutputStream fileStream = null;
+	    ObjectOutputStream objStream = null;
+	    File file = new File(plugin.getDataFolder() + "/auth.dat");
+	    try {
+	      fileStream = new FileOutputStream(file.getAbsolutePath());
+	      objStream = new ObjectOutputStream(fileStream);
+	      objStream.writeObject(authMap);
+	    } catch (Exception e) {
+	      e.printStackTrace();
+	    } finally {
+	      // [?] try to self-contain the error handling for this method
+	      try {
+	        if (objStream != null)
+	          objStream.close();
+	        if (fileStream != null)
+	          fileStream.close();
+	      } catch (IOException e) {
+	        plugin.log.severe(e.getMessage());
+	      }
+	    }
+	  }
+
 	public AuthInfo get(String name) {
 		return authMap.get(name.toLowerCase());
 	}

--- a/src/archangel/authplayer/AuthPlayer.java
+++ b/src/archangel/authplayer/AuthPlayer.java
@@ -21,7 +21,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  * @author Alex "Arcalyth" Riebs
  * License: Don't steal my shit. Give credit if you modify and/or redistribute any of my code.
  * Otherwise, you're free to do whatever else you want with it.
- * 
+ *
  * Also, the Bukkit license applies.
  */
 public class AuthPlayer extends JavaPlugin {
@@ -30,7 +30,7 @@ public class AuthPlayer extends JavaPlugin {
 	private final AuthPlayerBlockListener blockListener = new AuthPlayerBlockListener(this);
 
 	private AuthDatabase db;
-	
+
 	/*
 	 * @see org.bukkit.plugin.Plugin#onDisable()
 	 */
@@ -43,51 +43,49 @@ public class AuthPlayer extends JavaPlugin {
 	 * @see org.bukkit.plugin.Plugin#onEnable()
 	 */
 	@Override
-	public void onEnable() {		
+	public void onEnable() {
 		PluginManager pm = this.getServer().getPluginManager();
-		pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, 
-				Event.Priority.Normal, this);
-		pm.registerEvent(Event.Type.PLAYER_INTERACT, playerListener, 
-				Event.Priority.High, this);
-		pm.registerEvent(Event.Type.BLOCK_BREAK, blockListener, 
-				Event.Priority.High, this);
-		
+		pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, Event.Priority.Normal, this);
+		pm.registerEvent(Event.Type.PLAYER_INTERACT, playerListener, Event.Priority.High, this);
+		pm.registerEvent(Event.Type.BLOCK_BREAK, blockListener, Event.Priority.High, this);
+    pm.registerEvent(Event.Type.PLAYER_PRELOGIN, playerListener, Event.Priority.High, this);
+
 		db = new AuthDatabase(this);
-		
+
 		log.info("AuthPlayer enabled.");
 	}
-	
+
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
 		if (cmd.getName().equalsIgnoreCase("auth")) {
 			// [?] Provide help on /auth
 			if (args.length <= 0) return false;
-			
+
 			if (args[0].equals("list"))
 				return authList(sender);
 			else
 				return authLogin(sender, args);
 		}
-		
-		return false; 
+
+		return false;
 	}
-	
+
 	public boolean authList(CommandSender sender) {
 		sender.sendMessage("Registered players: \n" + getAuthDatabase().toString());
 		return true;
 	}
-	
+
 	public boolean authLogin(CommandSender sender, String[] args) {
 		if (args.length < 1) return false;
-		
+
 		// [?] We can only work with Player/CraftPlayer objects...
 		if (sender instanceof Player) {
 			Player player = (Player)sender;
 			String username = player.getName();
-			
+
 			AuthDatabase db = getAuthDatabase();
-			
+
 			// [?] Catch people that already have a name
-			if (!username.equals("Player")) {
+      if (!username.substring(0, 6).equalsIgnoreCase("Player")) {
 				// [?] Already have a name, and already in the db? Must be premium or already authenticated.
 				if (db.get(username) != null) {
 					player.sendMessage("You are already authenticated!");
@@ -96,7 +94,7 @@ public class AuthPlayer extends JavaPlugin {
 					player.sendMessage("You have registered and " +
 							"authenticated your name. Welcome, " + username + "!");
 				}
-				
+
 				return true;
 			} else {
 				// [?] I'm a guest, help!
@@ -104,15 +102,15 @@ public class AuthPlayer extends JavaPlugin {
 					player.sendMessage("Please supply a username AND password.");
 					return true;
 				}
-				
+
 				String loginName = args[0];
 				String password = args[1];
-				
-				if (loginName.equals("Player")) {
-					player.sendMessage("Nice try, sly guy.");
+
+				if (loginName.substring(0, 6).equalsIgnoreCase("Player")) {
+					player.sendMessage("Please do not start your username with \"player\". Try again.");
 					return true;
 				}
-			
+
 				// [?] Does the player exist on the server?
 				if (db.get(loginName) == null) {
 					db.add(loginName, new AuthInfo(player, password));
@@ -140,10 +138,10 @@ public class AuthPlayer extends JavaPlugin {
 							player.sendMessage("Could not authenticate with the given credentials.");
 						}
 					}
-				}					
+				}
 			}
 		}
-		
+
 		return true;
 	}
 

--- a/src/archangel/authplayer/AuthPlayer.java
+++ b/src/archangel/authplayer/AuthPlayer.java
@@ -14,138 +14,236 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import com.nijiko.permissions.PermissionHandler;
+import com.nijikokun.bukkit.Permissions.Permissions;
 
 /**
  * @author Alex "Arcalyth" Riebs
  * License: Don't steal my shit. Give credit if you modify and/or redistribute any of my code.
  * Otherwise, you're free to do whatever else you want with it.
- *
  * Also, the Bukkit license applies.
+ * 
+ * @author Thulinma
+ * Edited original work by Arclyth so it actually works as advertised.
+ * Also added an item pickup disabler for unauthed users.
  */
 public class AuthPlayer extends JavaPlugin {
-	Logger log = Logger.getLogger("Minecraft");
-	private final AuthPlayerPlayerListener playerListener = new AuthPlayerPlayerListener(this);
-	private final AuthPlayerBlockListener blockListener = new AuthPlayerBlockListener(this);
+  Logger log = Logger.getLogger("Minecraft");
+  private final AuthPlayerPlayerListener playerListener = new AuthPlayerPlayerListener(this);
+  private final AuthPlayerBlockListener blockListener = new AuthPlayerBlockListener(this);
 
-	private AuthDatabase db;
+  private AuthDatabase db;
+  private PermissionHandler permissions;
 
-	/*
-	 * @see org.bukkit.plugin.Plugin#onDisable()
-	 */
-	@Override
-	public void onDisable() {
-		log.info("AuthPlayer disabled.");
-	}
+  /*
+   * @see org.bukkit.plugin.Plugin#onDisable()
+   */
+  @Override
+  public void onDisable() {
+    PluginDescriptionFile pdfFile = getDescription();
+    log.info("AuthPlayer "+pdfFile.getVersion()+" disabled.");
+  }
 
-	/*
-	 * @see org.bukkit.plugin.Plugin#onEnable()
-	 */
-	@Override
-	public void onEnable() {
-		PluginManager pm = this.getServer().getPluginManager();
-		pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, Event.Priority.Normal, this);
-		pm.registerEvent(Event.Type.PLAYER_INTERACT, playerListener, Event.Priority.High, this);
-		pm.registerEvent(Event.Type.BLOCK_BREAK, blockListener, Event.Priority.High, this);
-    pm.registerEvent(Event.Type.PLAYER_PRELOGIN, playerListener, Event.Priority.High, this);
+  /*
+   * @see org.bukkit.plugin.Plugin#onEnable()
+   */
+  @Override
+  public void onEnable() {
+    PluginManager pm = this.getServer().getPluginManager();
+    pm.registerEvent(Event.Type.PLAYER_JOIN, playerListener, Event.Priority.Normal, this);
+    pm.registerEvent(Event.Type.PLAYER_PICKUP_ITEM, playerListener, Event.Priority.High, this);
+    pm.registerEvent(Event.Type.PLAYER_INTERACT, playerListener, Event.Priority.High, this);
+    pm.registerEvent(Event.Type.BLOCK_BREAK, blockListener, Event.Priority.High, this);
 
-		db = new AuthDatabase(this);
+    db = new AuthDatabase(this);
 
-		log.info("AuthPlayer enabled.");
-	}
+    PluginDescriptionFile pdfFile = getDescription();
+    log.info("AuthPlayer "+pdfFile.getVersion()+" enabled.");
+    setupPermissions();
+  }
 
-	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
-		if (cmd.getName().equalsIgnoreCase("auth")) {
-			// [?] Provide help on /auth
-			if (args.length <= 0) return false;
+  public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
+    if (cmd.getName().equalsIgnoreCase("auth")) {
+      // [?] Provide help on /auth
+      if (args.length <= 0) return false;
+      if (!(sender instanceof Player)) {
+        sender.sendMessage("This command cannot be used from the console");
+        return true;
+      }
 
-			if (args[0].equals("list"))
-				return authList(sender);
-			else
-				return authLogin(sender, args);
-		}
+      if (args[0].equals("list")){
+        if (hasPermission((Player)sender, "authplayer.list")){
+          sender.sendMessage("Registered players: \n" + getAuthDatabase().toString());
+        }else{
+          sender.sendMessage("You do not have permission to get the registered players list.");
+        }
+        return true;
+      }
 
-		return false;
-	}
+      if (args[0].equals("del") || args[0].equals("delete")){
+        if (hasPermission((Player)sender, "authplayer.delete")){
+          if (args.length <= 2){
+            sender.sendMessage("Usage: /auth delete <username>");
+            return true;
+          }
+          if (getAuthDatabase().get(args[1]) != null){
+            getAuthDatabase().delete(args[1]);
+            sender.sendMessage("User "+args[1]+" deleted from registered users.");
+          }else{
+            sender.sendMessage("There is no such registered user: "+args[1]);
+          }
+        }else{
+          sender.sendMessage("You do not have permission to delete registered players.");
+        }
+        return true;
+      }
 
-	public boolean authList(CommandSender sender) {
-		sender.sendMessage("Registered players: \n" + getAuthDatabase().toString());
-		return true;
-	}
+      if (args[0].equals("pass") || args[0].equals("password") || args[0].equals("passwd")){
+        if (hasPermission((Player)sender, "authplayer.passwd")){
+          if (args.length <= 2){
+            sender.sendMessage("Usage: /auth password <new password>");
+            return true;
+          }
+          String user = ((Player)sender).getName();
+          if (getAuthDatabase().get(user) != null){
+            getAuthDatabase().delete(args[1]);
+            getAuthDatabase().add(user, new AuthInfo((Player)sender, args[1]));
+            sender.sendMessage("Your password has been changed.");
+          }else{
+            sender.sendMessage("You are not currently logged in!");
+          }
+        }else{
+          sender.sendMessage("You do not have permission to change your password.");
+        }
+        return true;
+      }
 
-	public boolean authLogin(CommandSender sender, String[] args) {
-		if (args.length < 1) return false;
+      if (args[0].equals("create") || args[0].equals("new") || args[0].equals("newaccount") || args[0].equals("createaccount")){
+        if (hasPermission((Player)sender, "authplayer.create")){
+          if (args.length <= 3){
+            sender.sendMessage("Usage: /auth create <new username> <new password>");
+            return true;
+          }
+          if (getAuthDatabase().get(args[1]) == null){
+            getAuthDatabase().add(args[1], new AuthInfo((Player)sender, args[2]));
+            sender.sendMessage("New account created with name "+args[1]);
+          }else{
+            sender.sendMessage("This account already exists!");
+          }
+        }else{
+          sender.sendMessage("You do not have permission to create accounts.");
+        }
+        return true;
+      }
 
-		// [?] We can only work with Player/CraftPlayer objects...
-		if (sender instanceof Player) {
-			Player player = (Player)sender;
-			String username = player.getName();
+      return authLogin(sender, args);
+    }
+    return false;
+  }
 
-			AuthDatabase db = getAuthDatabase();
+  public boolean authLogin(CommandSender sender, String[] args) {
+    if (args.length < 1) return false;
 
-			// [?] Catch people that already have a name
-      if (!username.substring(0, 6).equalsIgnoreCase("Player")) {
-				// [?] Already have a name, and already in the db? Must be premium or already authenticated.
-				if (db.get(username) != null) {
-					player.sendMessage("You are already authenticated!");
-				} else {
-					db.add(username, new AuthInfo(player, args[0]));
-					player.sendMessage("You have registered and " +
-							"authenticated your name. Welcome, " + username + "!");
-				}
+    Player player = (Player)sender;
+    String username = player.getName();
 
-				return true;
-			} else {
-				// [?] I'm a guest, help!
-				if (args.length < 2) {
-					player.sendMessage("Please supply a username AND password.");
-					return true;
-				}
+    AuthDatabase db = getAuthDatabase();
 
-				String loginName = args[0];
-				String password = args[1];
+    // [?] Catch people that already have a name
+    if (!username.substring(0, 6).equalsIgnoreCase("Player")) {
+      // [?] Already have a name, and already in the db? Must be premium or already authenticated.
+      if (db.get(username) != null) {
+        player.sendMessage("You are already logged in!");
+      } else {
+        db.add(username, new AuthInfo(player, args[0]));
+        player.sendMessage("Password saved! You can now play.");
+      }
+      return true;
+    } else {
+      // [?] I'm a guest, help!
+      if (args.length < 2) {
+        player.sendMessage("Please supply a username AND password.");
+        return true;
+      }
 
-				if (loginName.substring(0, 6).equalsIgnoreCase("Player")) {
-					player.sendMessage("Please do not start your username with \"player\". Try again.");
-					return true;
-				}
+      String loginName = args[0];
+      String password = args[1];
 
-				// [?] Does the player exist on the server?
-				if (db.get(loginName) == null) {
-					db.add(loginName, new AuthInfo(player, password));
-					player.sendMessage("You have registered the name " + loginName + ". Use /auth again to authenticate.");
-					log.info("AuthPlayer: New user " + loginName + " created");
-				} else {
-					// [?] Player exists, is he online?
-					Player checkPlayer = getServer().getPlayer(loginName);
-					if (checkPlayer != null && checkPlayer.isOnline())
-						player.sendMessage("Someone is already authenticated as " + loginName + "!");
-					else {
-						// [?] Player isn't currently playing, so authenticate.
-						AuthInfo info = db.get(loginName);
-						if (info.authenticate(password)) {
-							EntityPlayer entity = ((CraftPlayer)player).getHandle();
-							entity.name = loginName;
-							entity.displayName = entity.name;
+      if (loginName.substring(0, 6).equalsIgnoreCase("Player")) {
+        player.sendMessage("Please do not start your username with \"player\". Try again.");
+        return true;
+      }
 
-							player.loadData();
-							player.teleport(player);
+      // [?] Does the player exist on the server?
+      if (db.get(loginName) == null) {
+        if (hasPermission((Player)sender, "authplayer.create")){
+          db.add(loginName, new AuthInfo(player, password));
+          player.sendMessage("You have registered the name " + loginName + ". Use /auth again to authenticate.");
+          log.info("AuthPlayer: New user " + loginName + " created");
+        }else{
+          player.sendMessage("You are not allowed to create new accounts.");
+          player.sendMessage("To create a new account: login to this server using your minecraft account, or ask an admin to create one for you.");
+        }
+      } else {
+        // [?] Player exists, is he online?
+        Player checkPlayer = getServer().getPlayer(loginName);
+        if (checkPlayer != null && checkPlayer.isOnline())
+          player.sendMessage("Someone is already playing as " + loginName + "!");
+        else {
+          // [?] Player isn't currently playing, so authenticate.
+          AuthInfo info = db.get(loginName);
+          if (info.authenticate(password)) {
+            EntityPlayer entity = ((CraftPlayer)player).getHandle();
+            entity.name = loginName;
+            entity.displayName = entity.name;
 
-							player.sendMessage("You are now authenticated. Welcome, " + entity.name + "!");
-							log.info("AuthPlayer: " + entity.name + " identified via /auth");
-						} else {
-							player.sendMessage("Could not authenticate with the given credentials.");
-						}
-					}
-				}
-			}
-		}
+            player.loadData();
+            player.teleport(player);
 
-		return true;
-	}
+            player.sendMessage("You are now logged in. Welcome, " + entity.name + "!");
+            log.info("AuthPlayer: " + entity.name + " identified via /auth");
+          } else {
+            player.sendMessage("Wrong username or password. Try again.");
+          }
+        }
+      }
+    }
 
-	public AuthDatabase getAuthDatabase() {
-		return db;
-	}
+    return true;
+  }
+
+  public AuthDatabase getAuthDatabase() {
+    return db;
+  }
+
+  private void setupPermissions() {
+    Plugin test = this.getServer().getPluginManager().getPlugin("Permissions");
+
+    if (permissions == null) {
+      if (test != null) {
+        permissions = ((Permissions) test).getHandler();
+      } else {
+        log.info("[AuthPlayer] Permission system not detected, allowing everything for operators only");
+      }
+    }
+  }
+
+  private boolean hasPermission(Player player, String node) {
+    if(permissions == null) {
+      if (node.equals("authplayer.passwd")){
+        return true; 
+      }else{
+        return player.isOp();
+      }
+    } else {
+      return permissions.has(player, node);
+    }
+  }
+
+
 }

--- a/src/archangel/authplayer/AuthPlayerPlayerListener.java
+++ b/src/archangel/authplayer/AuthPlayerPlayerListener.java
@@ -17,18 +17,34 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
-import org.bukkit.event.player.PlayerPreLoginEvent;
-import org.bukkit.Bukkit;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 
 /**
  * @author Alex "Arcalyth" Riebs
  * License: Don't steal my shit. Give credit if you modify and/or redistribute any of my code.
  * Otherwise, you're free to do whatever else you want with it.
- *
  * Also, the Bukkit license applies.
+ * 
+ * @author Thulinma
+ * Edited original work by Arclyth so it actually works as advertised.
+ * Also added an item pickup disabler for unauthed users.
  */
 public class AuthPlayerPlayerListener extends PlayerListener {
 	public static AuthPlayer plugin;
+	
+	private void setPlayerGuest(Player player){
+    player.sendMessage("You are currently a guest, and cannot play until you login to your account.");
+    player.sendMessage("Use /auth <username> <password> to login.");
+    // rename to player_entID to prevent people kicking each other off
+    EntityPlayer entity = ((CraftPlayer)player).getHandle();
+    entity.name = "Player_"+entity.id;
+    entity.displayName = entity.name;
+    //clear inventory
+    player.getInventory().clear();
+    //teleport to default spawn loc
+    player.teleport(player.getWorld().getSpawnLocation());	  
+    plugin.log.info("AuthPlayer: Nonpremium user has been asked to login.");
+	}
 
 	/**
 	 * @param authPlayer
@@ -37,64 +53,55 @@ public class AuthPlayerPlayerListener extends PlayerListener {
 		plugin = instance;
 	}
 
-	public void onPlayerPreLogin(PlayerPreLoginEvent event) {
-	  plugin.log.info("AuthPlayer: "+event.getName()+" prelogin: "+event.getKickMessage());
-	  
-	}
-
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 		String name = player.getName();
 
     if (name.substring(0, 6).equalsIgnoreCase("Player")) {
-      // rename to player_entID to prevent people kicking each other off
-      player.sendMessage("You are currently a guest, and cannot play until you authenticate yourself. Use /auth to authenticate.");
-      EntityPlayer entity = ((CraftPlayer)player).getHandle();
-      entity.name = "Player_"+entity.id;
-      entity.displayName = entity.name;
-      player.loadData();
-      player.teleport(player);
+      setPlayerGuest(player);
 		} else {
       // Check if player is real player, first...
 		  String inputLine = "";
 		  try{
-		    URL mcheck = new URL("http://www.minecraft.net/game/checkserver.jsp?user="+name+"&serverId="+Bukkit.getServer().getServerId());
-		    plugin.log.info("AuthPlayer:  Checking URL: http://www.minecraft.net/game/checkserver.jsp?user="+name+"&serverId="+Bukkit.getServer().getServerId());
+		    URL mcheck = new URL("http://www.minecraft.net/game/checkserver.jsp?premium="+name);
 		    URLConnection mcheckc = mcheck.openConnection();
 		    mcheckc.setReadTimeout(1500);
 		    BufferedReader in = new BufferedReader(new InputStreamReader(mcheckc.getInputStream()));
 		    inputLine = in.readLine();
 		    in.close();
 		  } catch(Exception e){
-		    plugin.log.info("AuthPlayer: minecraft.net check error: "+e.getMessage());
+		    plugin.log.info("AuthPlayer: Premium check error, assuming nonpremium: "+e.getMessage());
 		  }
-      plugin.log.info("AuthPlayer: minecraft.net response was "+inputLine);
-      if (inputLine.equals("YES")){
+      if (inputLine.equals("PREMIUM")){
         // [?] Tell real players to enter themselves into the AuthDB
         if (plugin.getAuthDatabase().get(name) == null) {
-          player.sendMessage("Welcome, " + name + "! It appears this is your first time playing on this server. " +
-              "Please authenticate yourself with the server by using /auth <password> to create a password for this account.");
+          player.sendMessage("Welcome, " + name + "! It appears this is your first time playing on this server.");
+          player.sendMessage("Please create a password for your account by typing /auth <password>");
+          player.sendMessage("This will allow you to play even if minecraft login servers are down.");
+          player.sendMessage("The server admin can see what you pick as password so don't use the same password as your Minecraft account!");
         } else {
-          player.sendMessage("You are now authenticated. Welcome, " + name + "!");
-          plugin.log.info("AuthPlayer: " + name + " identified on join");
+          plugin.log.info("AuthPlayer: Premium user " + name + " auto-identified.");
         }
       } else {
-        // Not a real player. Rename to "player_entID" and display login request.
-        player.sendMessage("You are currently a guest, and cannot play until you authenticate yourself. Use /auth to authenticate.");
-        EntityPlayer entity = ((CraftPlayer)player).getHandle();
-        entity.name = "Player_"+entity.id;
-        entity.displayName = entity.name;
-        plugin.log.info("AuthPlayer: " + name + " UNidentified on join, failed minecraft.net check!");
+        setPlayerGuest(player);
       }
 		}
 	}
 
-	public void onPlayerInteract(PlayerInteractEvent event) {
+	public void onPlayerInteract(PlayerInteractEvent event){
 		Player player = event.getPlayer();
-
 		if (plugin.getAuthDatabase().get(player.getName()) == null) {
 			event.setCancelled(true);
 			player.sendMessage("You cannot play until you are authenticated.");
 		}
 	}
+	
+	public void onPlayerPickupItem(PlayerPickupItemEvent event){
+    Player player = event.getPlayer();
+    if (plugin.getAuthDatabase().get(player.getName()) == null) {
+      event.setCancelled(true);
+      player.sendMessage("You cannot play until you are authenticated.");
+    }
+  }
+	
 }

--- a/src/archangel/authplayer/AuthPlayerPlayerListener.java
+++ b/src/archangel/authplayer/AuthPlayerPlayerListener.java
@@ -5,50 +5,93 @@
  */
 package archangel.authplayer;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+import net.minecraft.server.EntityPlayer;
+
+import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
+import org.bukkit.event.player.PlayerPreLoginEvent;
+import org.bukkit.Bukkit;
 
 /**
  * @author Alex "Arcalyth" Riebs
  * License: Don't steal my shit. Give credit if you modify and/or redistribute any of my code.
  * Otherwise, you're free to do whatever else you want with it.
- * 
+ *
  * Also, the Bukkit license applies.
  */
 public class AuthPlayerPlayerListener extends PlayerListener {
 	public static AuthPlayer plugin;
-	
+
 	/**
 	 * @param authPlayer
 	 */
 	public AuthPlayerPlayerListener(AuthPlayer instance) {
 		plugin = instance;
 	}
-	
+
+	public void onPlayerPreLogin(PlayerPreLoginEvent event) {
+	  plugin.log.info("AuthPlayer: "+event.getName()+" prelogin: "+event.getKickMessage());
+	  
+	}
+
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 		String name = player.getName();
 
-		if (name.equals("Player")) {
-			player.sendMessage("You are currently a guest, and cannot play until" +
-					" you authenticate yourself. Use /auth to authenticate.");
+    if (name.substring(0, 6).equalsIgnoreCase("Player")) {
+      // rename to player_entID to prevent people kicking each other off
+      player.sendMessage("You are currently a guest, and cannot play until you authenticate yourself. Use /auth to authenticate.");
+      EntityPlayer entity = ((CraftPlayer)player).getHandle();
+      entity.name = "Player_"+entity.id;
+      entity.displayName = entity.name;
+      player.loadData();
+      player.teleport(player);
 		} else {
-			// [?] Tell real players to enter themselves into the AuthDB
-			if (plugin.getAuthDatabase().get(name) == null) {
-				player.sendMessage("Welcome, " + name + "! It appears this is your first time playing on this server. " +
-						"Please authenticate yourself with the server by using /auth <password> to create a password for this account.");
-			} else {
-				player.sendMessage("You are now authenticated. Welcome, " + name + "!");
-				plugin.log.info("AuthPlayer: " + name + " identified on join");
-			}
+      // Check if player is real player, first...
+		  String inputLine = "";
+		  try{
+		    URL mcheck = new URL("http://www.minecraft.net/game/checkserver.jsp?user="+name+"&serverId="+Bukkit.getServer().getServerId());
+		    plugin.log.info("AuthPlayer:  Checking URL: http://www.minecraft.net/game/checkserver.jsp?user="+name+"&serverId="+Bukkit.getServer().getServerId());
+		    URLConnection mcheckc = mcheck.openConnection();
+		    mcheckc.setReadTimeout(1500);
+		    BufferedReader in = new BufferedReader(new InputStreamReader(mcheckc.getInputStream()));
+		    inputLine = in.readLine();
+		    in.close();
+		  } catch(Exception e){
+		    plugin.log.info("AuthPlayer: minecraft.net check error: "+e.getMessage());
+		  }
+      plugin.log.info("AuthPlayer: minecraft.net response was "+inputLine);
+      if (inputLine.equals("YES")){
+        // [?] Tell real players to enter themselves into the AuthDB
+        if (plugin.getAuthDatabase().get(name) == null) {
+          player.sendMessage("Welcome, " + name + "! It appears this is your first time playing on this server. " +
+              "Please authenticate yourself with the server by using /auth <password> to create a password for this account.");
+        } else {
+          player.sendMessage("You are now authenticated. Welcome, " + name + "!");
+          plugin.log.info("AuthPlayer: " + name + " identified on join");
+        }
+      } else {
+        // Not a real player. Rename to "player_entID" and display login request.
+        player.sendMessage("You are currently a guest, and cannot play until you authenticate yourself. Use /auth to authenticate.");
+        EntityPlayer entity = ((CraftPlayer)player).getHandle();
+        entity.name = "Player_"+entity.id;
+        entity.displayName = entity.name;
+        plugin.log.info("AuthPlayer: " + name + " UNidentified on join, failed minecraft.net check!");
+      }
 		}
 	}
-	
+
 	public void onPlayerInteract(PlayerInteractEvent event) {
 		Player player = event.getPlayer();
-		
+
 		if (plugin.getAuthDatabase().get(player.getName()) == null) {
 			event.setCancelled(true);
 			player.sendMessage("You cannot play until you are authenticated.");

--- a/src/archangel/authplayer/plugin.yml
+++ b/src/archangel/authplayer/plugin.yml
@@ -1,14 +1,16 @@
 name: AuthPlayer
 main: archangel.authplayer.AuthPlayer
-version: 1.1
+version: 1.2
+description: Provides alternate login when minecraft.net login servers are down.
+authors: [Arcalyth, Thulinma]
 
 commands:
-    listauth:
-        description: List authenticated players.
     auth:
-        description: Authenticate a player.
+        description: AuthPlayer account maintenance command.
         usage: |
-            (Warning: It is not recommended to use the same password for this authentication plugin as your actual Minecraft account.)
-            ---
-            /auth [username] <password> - Register or log into account.
-            /auth list - List registered players
+            /auth <username> <password> - Log into or create an account (as guest).
+            /auth <password> - Create an account (as premium user).
+            /auth list - List registered players.
+            /auth delete <username> - Delete a registered player.
+            /auth password <new password> - Change your password.
+            /auth create <username> <password> - Create a new account for somebody else.

--- a/src/archangel/authplayer/plugin.yml
+++ b/src/archangel/authplayer/plugin.yml
@@ -1,6 +1,6 @@
 name: AuthPlayer
 main: archangel.authplayer.AuthPlayer
-version: 1.0
+version: 1.1
 
 commands:
     listauth:


### PR DESCRIPTION
Hey, I love the simplicity of this plugin, but as you may have heard from others - it doesn't work.

I added a lot of code to your plugin, and now it can actually detect the difference between real accounts and spoofed names. This requires some setup as well as a HTTP server, see the included .php file for more information (it is quite well commented, I'd say).

I also added permissions support, as well as the ability for admins to delete/create accounts, the ability to disable guest accounts (meaning people need a real minecraft account to be able to create a local account) and the ability for users to change their own passwords.

If permissions are not installed, the plugin works like you'd expect - users can only create accounts if they already have a minecraft.net account and can change their passwords. Account deleting and creating accounts for names you do not own is limited to server ops. If permissions are installed, all of this can be fine-tuned as much as required.

Hope you will update your plugin with these modifications - I listed myself as co-author, since I pretty much made the entire thing twice as big/complicated :-)

If you have any questions, let me know.
